### PR TITLE
Add 2xl breakpoint from Tailwind 2.0

### DIFF
--- a/custom-device-presets.py
+++ b/custom-device-presets.py
@@ -18,6 +18,7 @@ breakpointOptions = [
         {"size": 768, "title": "Tailwind md"},
         {"size": 1024, "title": "Tailwind lg"},
         {"size": 1280, "title": "Tailwind xl"},
+        {"size": 1536, "title": "Tailwind 2xl"},
         {"size": 2560, "title": "4K"}]},
     {"name": "bootstrap4", "sizes": [
         {"size": 320, "title": "BS4 xs"},


### PR DESCRIPTION
Tailwind added a new breakpoint in version 2.0.

https://blog.tailwindcss.com/tailwindcss-v2#extra-wide-2-xl-breakpoint